### PR TITLE
Split out 3.9 / 2.5.3 test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,54 +13,53 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        pymodbus-version: ["2.5.3", "3.0.2", "3.1.3", "3.2.2", "3.3.1", "3.4.1", "3.5.4", "3.6.9", "3.7.2"]
-        exclude:
-        - python-version: "3.10"
-          pymodbus-version: "2.5.3"
-        - python-version: "3.11"
-          pymodbus-version: "2.5.3"
-        - python-version: "3.12"
-          pymodbus-version: "2.5.3"
-        - python-version: "3.13"
-          pymodbus-version: "2.5.3"
-        - python-version: "3.14"
-          pymodbus-version: "2.5.3"
-
+        pymodbus-version: ["3.0.2", "3.1.3", "3.2.2", "3.3.1", "3.4.1", "3.5.4", "3.6.9", "3.7.2"]
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        allow-prereleases: true
-        python-version: ${{ matrix.python-version }}
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-        enable-cache: true
-    - name: Install dependencies
-      run: |
-        uv sync --all-extras
-        if [ ${{ matrix.pymodbus-version }} == "2.5.3" ]; then
-          uv pip install pymodbus==2.5.3 --no-deps
-        else
-          uv add pymodbus==${{ matrix.pymodbus-version }}
-        fi
-    - name: Lint with ruff
-      run: |
-        uv run ruff check .
-    - name: Check types with mypy
-      run: |
-        uv run mypy productivity
-    - name: Pytest
-      run: |
-        uv run pytest
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          allow-prereleases: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+      - name: Install dependencies
+        run: |
+          uv sync --all-extras
+      - name: Lint with ruff
+        run: uv run ruff check .
+      - name: Check types with mypy
+        run: uv run mypy productivity
+      - name: Pytest
+        run: uv run pytest
+
+  py39-pymodbus253:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.9"
+          enable-cache: true
+      - name: Install dependencies
+        run: |
+          uv sync --all-extras
+          uv pip install "pymodbus==2.5.3" --no-deps
+      - name: Lint with ruff
+        run: uv run ruff check .
+      - name: Check types with mypy
+        run: uv run mypy productivity
+      - name: Pytest
+        run: uv run pytest
 
 permissions:
   contents: read


### PR DESCRIPTION
This makes the matrix easier to see, and it will also be easy when we drop the older versions.
