### PR TITLE
Drop Python 3.9 and pymodbus 2.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         pymodbus-version: ["3.0.2", "3.1.3", "3.2.2", "3.3.1", "3.4.1", "3.5.4", "3.6.9", "3.7.2"]
     steps:
       - uses: actions/checkout@v5
@@ -27,26 +27,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --all-extras
-      - name: Lint with ruff
-        run: uv run ruff check .
-      - name: Check types with mypy
-        run: uv run mypy productivity
-      - name: Pytest
-        run: uv run pytest
-
-  py39-pymodbus253:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.9"
-          enable-cache: true
-      - name: Install dependencies
-        run: |
-          uv sync --all-extras
-          uv pip install "pymodbus==2.5.3" --no-deps
       - name: Lint with ruff
         run: uv run ruff check .
       - name: Check types with mypy

--- a/productivity/driver.py
+++ b/productivity/driver.py
@@ -3,8 +3,6 @@ Python driver for AutomationDirect Productivity Series PLCs.
 
 Distributed under the GNU General Public License v2
 """
-from __future__ import annotations
-
 import csv
 import logging
 import pydoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "productivity"
 version = "0.13.0"
 description = "Python driver for AutomationDirect Productivity Series PLCs."
 dependencies = [
-  "pymodbus>=2.4.0; python_version == '3.9'",
-  "pymodbus>=3.0.2,<3.8.0; python_version >= '3.10'",
+  "pymodbus>=3.0.2,<3.8.0",
   "pyYAML",
 ]
 authors = [
@@ -24,7 +23,6 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python 3.9 went EOL in Oct 2025, and it's more trouble than it's worth supporting `pymodbus 2.5.x`
